### PR TITLE
Fix for CONFIG_DIR using $APP_DIR before it was set

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -2,9 +2,9 @@
 
 NODE_ENV="production"
 PORT="3000"
-CONFIG_DIR="$APP_DIR"
 APP_DIR="/var/www/example.com"
 NODE_APP="app.js"
+CONFIG_DIR="$APP_DIR"
 PID_DIR="$APP_DIR/pid"
 PID_FILE="$PID_DIR/app.pid"
 LOG_DIR="$APP_DIR/log"


### PR DESCRIPTION
It looks like a few things got reorganised, and the `CONFIG_DIR` value will end up being blank by default, instead of `$APP_DIR`. This is probably not the intended behaviour, as otherwise the variable is unused.
