### PR TITLE
Change ps ef for ps aux

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -42,7 +42,7 @@ get_pid() {
 
 is_running() {
     PID=$(get_pid)
-    ! [ -z "$(ps ef | awk '{print $1}' | grep "^$PID$")" ]
+    ! [ -z "$(ps aux | awk '{print $2}' | grep "^$PID$")" ]
 }
 
 start_it() {


### PR DESCRIPTION
If the `service app start` command is ran by some other tty or by a script, ps ef won't be able to find the pid. Changing it this way will let us see the pid no matter what.

Most likely fixes #17 
