### PR TITLE
Fixes issue where modules wouldn't load

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -48,6 +48,8 @@ is_running() {
 start_it() {
     mkdir -p "$PID_DIR"
     mkdir -p "$LOG_DIR"
+    
+    cd "$APP_DIR"
 
     echo "Starting node app ..."
     PORT="$PORT" NODE_ENV="$NODE_ENV" NODE_CONFIG_DIR="$CONFIG_DIR" $NODE_EXEC "$APP_DIR/$NODE_APP"  1>"$LOG_FILE" 2>&1 &


### PR DESCRIPTION
Without this option, even though the config_dir is parsed in the run command, modules will fail to load because they cannot be found, presumably because node is looking in the OS root instead of the actual folder. CD'ing into the directory before executing fixes the problem, at least for me. Now I'm a happy camper. :)