### PR TITLE
Only background the node process and not the shell

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -55,7 +55,7 @@ start_it() {
     chown $USER:$USER "$LOG_DIR"
 
     echo "Starting $APP_NAME ..."
-    echo "cd $APP_DIR && PORT=$PORT NODE_ENV=$NODE_ENV NODE_CONFIG_DIR=$CONFIG_DIR $NODE_EXEC $APP_DIR/$NODE_APP $KWARGS 1>$LOG_FILE 2>&1 & echo \$! > $PID_FILE" | sudo -i -u $USER
+    echo "cd $APP_DIR; PORT=$PORT NODE_ENV=$NODE_ENV NODE_CONFIG_DIR=$CONFIG_DIR $NODE_EXEC $APP_DIR/$NODE_APP $KWARGS 1>$LOG_FILE 2>&1 & echo \$! > $PID_FILE" | sudo -i -u $USER
     echo "$APP_NAME started with pid $(get_pid)"
 }
 


### PR DESCRIPTION
By using '&&' to run both 'cd' and the node process it is essentially
backgrounding the whole shell command. Using a semi-colon separates both
commands and only backgrounds the node process.