### PR TITLE
Merge the grep match into the awk expression

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -46,7 +46,7 @@ get_pid() {
 
 is_running() {
     PID=$(get_pid)
-    ! [ -z "$(ps aux | awk '{print $2}' | grep "^$PID$")" ]
+    ! [ -z "$(ps aux | awk -v PID="$PID" '$1 == PID {print $2}')" ]
 }
 
 start_it() {


### PR DESCRIPTION
We can merge the grep pattern match into the awk expression.
Thus grep isn't called anymore in the script.