### PR TITLE
Detect is running by asking the proc file system

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -45,8 +45,8 @@ get_pid() {
 }
 
 is_running() {
-    PID=$(get_pid)
-    ! [ -z "$(ps aux | awk '{print $2}' | grep "^$PID$")" ]
+    PID="$(get_pid)"
+    [ -d /proc/$PID ]
 }
 
 start_it() {


### PR DESCRIPTION
Utilize the `/proc` file system to determine if the process is running instead of querying and parsing the output of `ps`.

Fixes #40