### PR TITLE
Catch STDERR on stop_process

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -68,7 +68,9 @@ start_it() {
 stop_process() {
     PID=$(get_pid)
     echo "Killing process $PID"
-    pkill -P $PID
+    # Not galmourous, but mutes bash's terminated messages
+    kill -- -$(ps -o pgid= $PID | grep -o [0-9]*)
+    wait $PID 2>/dev/null
 }
 
 remove_pid_file() {

--- a/init.d/node-app
+++ b/init.d/node-app
@@ -68,7 +68,7 @@ start_it() {
 stop_process() {
     PID=$(get_pid)
     echo "Killing process $PID"
-    # Not galmourous, but mutes bash's terminated messages
+    # Not glamorous, but mutes bash's terminated messages
     kill -- -$(ps -o pgid= $PID | grep -o [0-9]*)
     wait $PID 2>/dev/null
 }


### PR DESCRIPTION
If you use this script on a crontab, and the account has email forwarding enabled, you'll get spammed with terminated messages from bash, even though you are catching stdout with `> /dev/null`

```
-bash: line 1:  1675 Terminated              PORT=80 NODE_ENV=production NODE_CONFIG_DIR=/opt/web-hooks /usr/bin/node  /opt/web-hooks/bin/www &>>/var/log/td-web-hooks.log
```

I tried pkill, but that didn't work with wait. and we currently only store that paren't PID which will kill the bash running node, but not node. Hence the subshell to find the process group ID and use kill. It might be more elegant to just save the process group ID from the get go, but this works well without refactoring.
https://stackoverflow.com/questions/5719030/bash-silently-kill-background-function-process