### PR TITLE
Background node process only

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -61,15 +61,22 @@ start_it() {
     chown $USER:$GROUP "$LOG_DIR"
 
     echo "Starting $APP_NAME ..."
-    echo "cd $APP_DIR && PORT=$PORT NODE_ENV=$NODE_ENV NODE_CONFIG_DIR=$CONFIG_DIR $NODE_EXEC $APP_DIR/$NODE_APP $KWARGS 1>$LOG_FILE 2>&1 & echo \$! > $PID_FILE" | sudo -i -u $USER
+    echo "cd $APP_DIR
+        if [ $? -ne 0 ]; then
+          exit
+        fi
+        PORT=$PORT
+        NODE_ENV=$NODE_ENV
+        NODE_CONFIG_DIR=$CONFIG_DIR
+        $NODE_EXEC $APP_DIR/$NODE_APP $KWARGS &>>$LOG_FILE &
+        echo \$! > $PID_FILE" | sudo -i -u $USER
     echo "$APP_NAME started with pid $(get_pid)"
 }
 
 stop_process() {
     PID=$(get_pid)
     echo "Killing process $PID"
-    # Not glamorous, but mutes bash's terminated messages
-    kill -- -$(ps -o pgid= $PID | grep -o [0-9]*)
+    kill $PID
     wait $PID 2>/dev/null
 }
 


### PR DESCRIPTION
 Cleans up stop_process and saves memory. Git doesn't take kindly to long one liners, hence the split.

One potential issue is if this is in anyone's poorly implemented CI, the update will result in two node instances, one working zombie and one probably not. To have this auto update properly, you should kill with the current version and start with the new one... not update then restart. I don't think that's too much of an issue as anyone who seriously uses this has probably customized it... TLS ports, directories etc

related to #49 and #34 by @clascelles
