### PR TITLE
NODE_ENV fix

### DIFF
--- a/init.d/node-app
+++ b/init.d/node-app
@@ -65,10 +65,11 @@ start_it() {
         if [ $? -ne 0 ]; then
           exit
         fi
+        set -a
         PORT=$PORT
         NODE_ENV=$NODE_ENV
         NODE_CONFIG_DIR=$CONFIG_DIR
-        $NODE_EXEC $APP_DIR/$NODE_APP $KWARGS &>>$LOG_FILE &
+        $NODE_EXEC \"$APP_DIR\"/$NODE_APP $KWARGS &>> \"$LOG_FILE\" &
         echo \$! > $PID_FILE" | sudo -i -u $USER
     echo "$APP_NAME started with pid $(get_pid)"
 }


### PR DESCRIPTION
#50 introduced a regression which stops NODE_ENV from passing to node.

Also highlights some space escaping issues... dirs with spaces should be supported. If you name your app `rm -rf .. js` we can't help you